### PR TITLE
Created the QueryResult object within the query api object

### DIFF
--- a/sfdc_api/query/query.py
+++ b/sfdc_api/query/query.py
@@ -1,16 +1,47 @@
 from sfdc_api.utils import Connection
-from urllib.parse import urlencode, quote
+from urllib.parse import quote
+
+
+class QueryResult(dict):
+    def __init__(self, conn, *args, **kw):
+        self.__CONNECTION = conn
+        super(QueryResult, self).__init__(*args, **kw)
+
+    def query_more(self):
+        if 'nextRecordsUrl' in self.keys() and self.get('nextRecordsUrl') != '':
+            endpoint = self.__CONNECTION.CONNECTION_DETAILS["instance_url"] + self.get('nextRecordsUrl')
+            return QueryResult(self.__CONNECTION, **self.__CONNECTION.send_http_request(endpoint, "GET",
+                                                                                        self.__CONNECTION.HTTPS_HEADERS[
+                                                                                            'rest_authorized_headers']))
+        return None
+
+    def query_all(self):
+        while True:
+            if 'nextRecordsUrl' in self.keys() and self.get('nextRecordsUrl') != '':
+                ret = self.query_more()
+                if ret is None or self['done']:
+                    break
+                self['totalSize'] = ret['totalSize']
+                self['done'] = ret['done']
+                self['records'].extend(ret['records'])
+                if 'nextRecordsUrl' in ret.keys():
+                    self['nextRecordsUrl'] = ret['nextRecordsUrl']
+                else:
+                    del self['nextRecordsUrl']
+            else:
+                break
+        return self
 
 
 class Query:
     _CONNECTION = None
 
-    def __init__(self, conn):
+    def __init__(self, conn: Connection):
         self._CONNECTION = conn
 
-    def query(self, query='', explain=False, query_identifier=''):
+    def query(self, query='', explain=False, query_identifier='') -> QueryResult:
         endpoint = self._CONNECTION.CONNECTION_DETAILS["instance_url"] + '/services/data/v' + \
-                       str(self._CONNECTION.VERSION) + '/query/'
+                   str(self._CONNECTION.VERSION) + '/query/'
         if query and not explain and not query_identifier:
             endpoint += '?q=' + quote(query)
         elif query and explain and not query_identifier:
@@ -21,4 +52,6 @@ class Query:
             endpoint += quote(query_identifier)
         else:
             raise ValueError('Incorrect parameter configuration')
-        return self._CONNECTION.send_http_request(endpoint, "GET", self._CONNECTION.HTTPS_HEADERS['rest_authorized_headers'])
+        return QueryResult(self._CONNECTION, **self._CONNECTION.send_http_request(endpoint, "GET",
+                                                                                  self._CONNECTION.HTTPS_HEADERS[
+                                                                                      'rest_authorized_headers']))


### PR DESCRIPTION
This pull request creates a wrapper object to encapsulate return values from the query api. All that changes is that we return an object that extends the native dict object. For now this seems to provide a way to not break any previous releases, the QueryResult object is printable, index-able, and json dumpable. 

The only extra features on this object are a query more method and a query_all method to neatly pull down more data from the query api. While query_all provides a synchronous way to pull down all the data corresponding to a query, the query_more method could be wrapped up for use in asynchronous programs where multiple large queries are taking place. 